### PR TITLE
Add docs directory with README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Documentation
+
+This project provides an HTTP API for retrieving and processing Fate/Grand Order game data. The API is built with FastAPI and exposes endpoints for raw and processed data.
+
+## Quick Start
+1. Install the dependencies using [Poetry](https://python-poetry.org/docs/):
+   ```sh
+   poetry install
+   ```
+2. Configure environment variables as described in the root `README.md`.
+3. Start the development server:
+   ```sh
+   uvicorn app.main:app
+   ```
+
+Browse the running API at `http://127.0.0.1:8000` or visit the live API at `https://api.atlasacademy.io`.
+
+## Development
+- Lint the code with `./scripts/lint.ps1`.
+- Format the code with `./scripts/format.ps1`.
+- Run the test suite with `./scripts/test.ps1`.
+
+## Project Structure
+- `app/` – API implementation and supporting modules.
+- `scripts/` – Helper scripts for linting, formatting, exporting data and more.
+- `tests/` – Automated tests.
+
+For additional information, refer to the root `README.md` and the `CHANGELOG.md` file.


### PR DESCRIPTION
## Summary
- create `docs` folder
- add an introductory README for the project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asgi_lifespan')*

------
https://chatgpt.com/codex/tasks/task_e_68468ca0be608324b508a4ebed2a6b93